### PR TITLE
chore: Correct the entry file path in the example app/build.gradle

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -73,7 +73,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js"
+    entryFile: "example/index.js",
+    root: "../../../"
 ]
 
 apply from: "../../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
# Overview
A simple change to ensure the path to the entry file is correct in `example/app/build.gradle`.

# Test Plan
Tested that the example app builds and compiles for Android.