### PR TITLE
Move the haste imported functions into the library

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -11,8 +11,7 @@
 import {RNCGeolocation, GeolocationEventEmitter} from './nativeInterface';
 
 import invariant from 'invariant';
-import logError from 'logError'; // TODO: Remove this haste import
-import warning from 'fbjs/lib/warning'; // TODO: Maybe remove fbjs
+import {logError, warning} from './utils';
 
 let subscriptions = [];
 let updatesEnabled = false;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+/**
+ * Small utility that can be used as an error handler. You cannot just pass
+ * `console.error` as a failure callback - it's not properly bound.  If passes an
+ * `Error` object, it will print the message and stack.
+ */
+const logError = function(...args: $ReadOnlyArray<mixed>) {
+  if (args.length === 1 && args[0] instanceof Error) {
+    const err = args[0];
+    console.error('Error: "' + err.message + '".  Stack:\n' + err.stack);
+  } else {
+    console.error.apply(console, args);
+  }
+};
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+const warning = __DEV__
+  ? function(condition, format, ...args) {
+      if (format === undefined) {
+        throw new Error(
+          '`warning(condition, format, ...args)` requires a warning ' +
+          'message argument'
+        );
+      }
+      if (!condition) {
+        var argIndex = 0;
+        var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+        if (typeof console !== 'undefined') {
+          console.error(message);
+        }
+        try {
+          // --- Welcome to debugging React ---
+          // This error was thrown as a convenience so that you can use this stack
+          // to find the callsite that caused this warning to fire.
+          throw new Error(message);
+        } catch (x) {}
+      }
+    }
+  : function() {};
+
+module.exports = {
+  logError,
+  warning
+};


### PR DESCRIPTION
# Overview
For this library to work as an NPM library we need to move the haste imported files into the library code. I have moved the two required functions into a new `js/utils.js` file and updated the imports.

We will likely remove the need for these functions once we begin altering the library code, however, this is a short-term fix so we can get a 1.0.0 published before RN 0.60 is released.

# Test Plan
Install and use the library as a normal NPM dependency.