### PR TITLE
feat: export GeolocationError typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -33,7 +33,7 @@ export type GeolocationResponse = {
   timestamp: number;
 };
 
-type GeolocationError = {
+export type GeolocationError = {
   code: number;
   message: string;
   PERMISSION_DENIED: number;


### PR DESCRIPTION
# Overview
export the type `GeolocationError` so it can be used by a typescript project that needs to parse the error response


# Test Plan
Test with a TypeScript enabled project and see that type exports correctly.
