### PR TITLE
Fix anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ Check out the [example project](example) for more examples.
 
 ### Summary
 
-* [`setRNConfiguration`](README.md#setrnconfiguration)
-* [`requestAuthorization`](README.md#requestauthorization)
-* [`getCurrentPosition`](README.md#getcurrentposition)
-* [`watchPosition`](README.md#watchposition)
-* [`clearWatch`](README.md#clearwatch)
-* [`stopObserving`](README.md#stopobserving)
+* [`setRNConfiguration`](#setrnconfiguration)
+* [`requestAuthorization`](#requestauthorization)
+* [`getCurrentPosition`](#getcurrentposition)
+* [`watchPosition`](#watchposition)
+* [`clearWatch`](#clearwatch)
+* [`stopObserving`](#stopobserving)
 
 ---
 


### PR DESCRIPTION
# Overview
Currently all anchors in `README.md` cause address change. E.g. `setRNConfiguration` link in [Methods section](https://github.com/react-native-community/react-native-geolocation#methods) should lead to
```
https://github.com/react-native-community/react-native-geolocation#setrnconfiguration
```
but leads to
```
https://github.com/react-native-community/react-native-geolocation/blob/master/README.md#setrnconfiguration
```

This PR fixes that.
# Test Plan
Try clicking on the same link in [Methods section with the fix](https://github.com/lebedev/react-native-geolocation/tree/patch-1#methods).