### PR TITLE
fix: Include typings in npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "lib/",
     "js/",
+    "typings/",
     "/android",
     "!/android/build",
     "/ios",


### PR DESCRIPTION
# Overview

Typings are missing from the npm build since 8fe3bd42916caa7db517408edf41394b760ab651 introduces the files config.

Fixes #33

# Test Plan
N/A