### PR TITLE
Update README to reflect current iOS requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ protected List<ReactPackage> getPackages() {
 
 ### iOS
 
-You need to include the `NSLocationWhenInUseUsageDescription` key in Info.plist to enable geolocation when using the app. Geolocation is enabled by default when you create a project with `react-native init`.
+You need to include `NSLocationWhenInUseUsageDescription` and `NSLocationAlwaysAndWhenInUseUsageDescription` in `Info.plist` to enable geolocation when using the app. If your app supports iOS 10 and earlier, the `NSLocationAlwaysUsageDescription` key is also required. If these keys are not present in the `Info.plist`, authorization requests fail immediately and silently. Geolocation is enabled by default when you create a project with `react-native init`.
 
 In order to enable geolocation in the background, you need to include the 'NSLocationAlwaysUsageDescription' key in Info.plist and add location as a background mode in the 'Capabilities' tab in Xcode.
 


### PR DESCRIPTION
# Overview
Apple has recently made it mandatory to add the `NSLocationAlwaysUsageDescription` key to your `Info.plist` when you want to submit your app using Geolocation. If you do *not* also add the `NSLocationAlwaysAndWhenInUseUsageDescription` key, your app will submit, but Geolocation will silently fail. Therefore I updated the `README` to reflect the current way to add Geolocation to your `Info.plist` as per the [Apple documentation](https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization):

> **Important**
> You are required to include the NSLocationWhenInUseUsageDescription and NSLocationAlwaysAndWhenInUseUsageDescription keys in your app's Info.plist file. (If your app supports iOS 10 and earlier, the NSLocationAlwaysUsageDescription key is also required.) If those keys are not present, authorization requests fail immediately.

In my case, and [a few others](https://github.com/facebook/react-native/issues/19057), this solved issues where Geolocation stopped working.