### PR TITLE
Fix `NativeModules` typo in error when `RNCGeolocation` is missing from `NativeModules`

### DIFF
--- a/js/nativeInterface.js
+++ b/js/nativeInterface.js
@@ -14,7 +14,7 @@ const {RNCGeolocation} = NativeModules;
 
 // Produce an error if we don't have the native module
 if (!RNCGeolocation) {
-  throw new Error(`@react-native-community/geolocation: NativeModule.RNCGeolocation is null. To fix this issue try these steps:
+  throw new Error(`@react-native-community/geolocation: NativeModules.RNCGeolocation is null. To fix this issue try these steps:
 • Run \`react-native link @react-native-community/geolocation\` in the project root.
 • Rebuild and re-run the app.
 • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.


### PR DESCRIPTION
# Overview

Just a typo!

# Test Plan

Should need that :D 